### PR TITLE
Update users.j2 to correct syntax

### DIFF
--- a/templates/users.j2
+++ b/templates/users.j2
@@ -31,7 +31,7 @@ no {{ username }}
          {% set username = username + " secret 5 %s" % item.secret %}
       {% elif item.encryption is defined and item.encryption == 'sha512' %}
          {# sha512 encrypted secret #}
-         {% set username = username + " secret sha5 %s" % item.secret %}
+         {% set username = username + " secret sha512 %s" % item.secret %}
       {% else %}
          {# unencrypted secret #}
          {% set username = username + " secret %s" % item.secret %}


### PR DESCRIPTION
The "username" command requires to set full sha512 keyword before accepting password LINE. This fix addresses issue that sha512 encrypted secrets were not accepted.

tested on vEOS version 4.17.0F-3277845.ilchicagorel:

leaf1.lab(config)#username testuser1 privilege 15 role network-admin secret sha5 ?
  shell  Specify shell for the user
  <cr>   

leaf1.lab(config)#username testuser1 privilege 15 role network-admin secret sha512 ?
  LINE  The SHA512 ENCRYPTED user account password
