### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,5 @@ eos_save_running_config: true
 
 eos_ip_routing_enabled: no
 default_user_state: present
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 - name: Gather EOS configuration
   eos_command:
     commands: 'show running-config all | exclude \.\*'
@@ -21,87 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista EOS Hostname resources
-  eos_template:
-    src: hostname.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: hostname is defined
-
-- name: Arista EOS IP Routing resources
-  eos_template:
-    src: ip_routing.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: eos_ip_routing_enabled is defined
-
-- name: Arista EOS CLI User resources
-  eos_template:
-    src: users.j2
-    include_defaults: true
-    # Do not use the cached _eos_config for this template
-    # because certain required information is sanitized
-    # for security. We need to have the exact running-config.
-    # config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  # Block output from this step, to prevent unwanted
-  # information from being exposed.
-  no_log: true
-  register: users_result
-  notify: save running config
-  when: item.name is defined
-  with_items: "{{ eos_users | default([]) }}"
-
-- block:
-  # If the users task resulted in a change, we need to update
-  # _eos_config, to make the updated config available to any
-  # roles or tasks that may follow.
-  - name: Gather EOS configuration
-    eos_command:
-      commands: 'show running-config all | exclude \.\*'
-      provider: "{{ provider | default(omit) }}"
-      auth_pass: "{{ auth_pass | default(omit) }}"
-      authorize: "{{ authorize | default(omit) }}"
-      host: "{{ host | default(omit) }}"
-      password: "{{ password | default(omit) }}"
-      port: "{{ port | default(omit) }}"
-      transport: 'cli'
-      use_ssl: "{{ use_ssl | default(omit) }}"
-      username: "{{ username | default(omit) }}"
-    register: output
-    no_log: "{{ no_log | default(true) }}"
-
-  - name: Save EOS configuration
-    set_fact:
-      _eos_config: "{{ output.stdout[0] }}"
-    no_log: "{{ no_log | default(true) }}"
-
-  when: users_result | changed
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS System resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,87 @@
+# Perform the EOS System tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+
+- name: Arista EOS Hostname resources (Ansible <= 2.1)
+  eos_template:
+    src: hostname.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: hostname is defined
+
+- name: Arista EOS IP Routing resources (Ansible <= 2.1)
+  eos_template:
+    src: ip_routing.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: eos_ip_routing_enabled is defined
+
+- name: Arista EOS CLI User resources (Ansible <= 2.1)
+  eos_template:
+    src: users.j2
+    include_defaults: true
+    # Do not use the cached _eos_config for this template
+    # because certain required information is sanitized
+    # for security. We need to have the exact running-config.
+    # config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  # Block output from this step, to prevent unwanted
+  # information from being exposed.
+  no_log: true
+  register: users_result
+  notify: save running config
+  when: item.name is defined
+  with_items: "{{ eos_users | default([]) }}"
+
+- block:
+  # If the users task resulted in a change, we need to update
+  # _eos_config, to make the updated config available to any
+  # roles or tasks that may follow.
+  - name: Gather EOS configuration
+    eos_command:
+      commands: 'show running-config all | exclude \.\*'
+      provider: "{{ provider | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    register: output
+    no_log: "{{ no_log | default(true) }}"
+
+  - name: Save EOS configuration
+    set_fact:
+      _eos_config: "{{ output.stdout[0] }}"
+    no_log: "{{ no_log | default(true) }}"
+
+  when: users_result | changed

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,87 @@
+# Perform the EOS System tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+
+- name: Arista EOS Hostname resources (Ansible >= 2.2)
+  eos_config:
+    src: hostname.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: hostname is defined
+
+- name: Arista EOS IP Routing resources (Ansible >= 2.2)
+  eos_config:
+    src: ip_routing.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: eos_ip_routing_enabled is defined
+
+- name: Arista EOS CLI User resources (Ansible >= 2.2)
+  eos_config:
+    src: users.j2
+    defaults: true
+    # Do not use the cached _eos_config for this template
+    # because certain required information is sanitized
+    # for security. We need to have the exact running-config.
+    # config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  # Block output from this step, to prevent unwanted
+  # information from being exposed.
+  no_log: true
+  register: users_result
+  notify: save running config
+  when: item.name is defined
+  with_items: "{{ eos_users | default([]) }}"
+
+- block:
+  # If the users task resulted in a change, we need to update
+  # _eos_config, to make the updated config available to any
+  # roles or tasks that may follow.
+  - name: Gather EOS configuration
+    eos_command:
+      commands: 'show running-config all | exclude \.\*'
+      provider: "{{ provider | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    register: output
+    no_log: "{{ no_log | default(true) }}"
+
+  - name: Save EOS configuration
+    set_fact:
+      _eos_config: "{{ output.stdout[0] }}"
+    no_log: "{{ no_log | default(true) }}"
+
+  when: users_result | changed

--- a/test/testcases/users.yml
+++ b/test/testcases/users.yml
@@ -108,8 +108,6 @@ testcases:
       username baduser02 privilege 8 role network-operator secret 5 $1$j47ZatzU$ppPbrqfHZEqiR4G5QtdwG1
       username baduser03 privilege 6 role network-operator secret 5 $1$Zn3BYTLM$dAzIpKneVFKsh8W4qUStN/
       username baduser04 privilege 4 role network-admin secret sha512 $6$somesalt$rkDq7Az4Efjo.0vtRe7E/8UXZNB6.88eMNIaqLdpmULIFkw3gDNPFnjAX4Y9fiGFzVlOyaDr1X.YYUsczCeAB.
-      username baduser01 sshkey ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC5iZvhXxj8s4wa4YW4qo7brnrlBfX6/gpF63IOV7AgymtxNKNtHRP7GY6Ko2oOFL8uKkPtvUhcJy9eEr6ngb7ffweZGP5ssBAt7yHsmW4F8GEDzpl+WGTQCN4+q7ofl2JFK+QklZc0v1+HdiCCZqFduJIR7LdrRGH/WhhiF26toeSiQchh4pMXT3n2oNRila57ssihXzEY1mA9pKQM6ke7z3GiI6VHOw+9bdfymsf+MiKI5rXCZuZbZGu9TceNpY2n/492v+/G088w5aFogn8WQ44ESFDBXymDxCmhdlye48qFVA2WMqqsB8wvkZiaVpkgfvXiukl/O5JEzkltdDc/ baduser01@dut
-      username baduser03 sshkey ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIq8HJyNeMrKqkdidMqOqC2/vDGR2j4khK6EbPyHZ3nVswIa/yeg7G4L+hk/ZBgramNq6ZSLUkpUJ82N625+Jd/+LhdyneXycHLEkFlAMW/vNPtby6uob2Ew0l9Ovems+vnKLmliuOwNq0pZ0BpQfbCgi6xk/uiokb2TQUE7b2oSACWf9lFUmkFTGXngiVPkd4iySXrX++E+/XjspZZ0+PPKQ25BNq7oCFdlecikC7rqlm/Eg+lsyqkC1eDejnzWyTNZbsD5qbBdOSLWKeqPSeVEf/sCq/R1dk26FpoSFXBPbqpcJCcMzjhPza7/VWalLu1XrbnqXCl4ieKltvFSc1 baduser03@dut
 
   - name: Modify users
     arguments:


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update test cases for changes in Ansible 2.2
